### PR TITLE
Chart related tasks

### DIFF
--- a/src/components/ChartsSection.jsx
+++ b/src/components/ChartsSection.jsx
@@ -3,11 +3,11 @@ import DinosaurTypeChart from "./DoughnutChart";
 
 function ChartsSection() {
   return (
-    <section className="container text-text-light py-14 bg-primary">
+    <section className="container text-text-light py-14 bg-primary ">
       <h2 className="text-text-light font-bold text-2xl pb-7">Charts</h2>
       <div className="flex flex-col lg:flex-row justify-center gap-10">
         <div className="flex flex-col gap-5 lg:gap-10 lg:w-6/12">
-          <div className="flex justify-center order-2 lg:order-1 w-5/6 sm:w-full m-auto">
+          <div className="flex justify-center order-2 lg:order-1 w-full m-auto h-[16rem] sm:h-[32rem] 2xl:h-[40rem]">
             <DietChart />
           </div>
           <div className="flex flex-col justify-center text-center w-4/5 m-auto order-1 lg:order-2">
@@ -22,7 +22,7 @@ function ChartsSection() {
           </div>
         </div>
         <div className="flex flex-col gap-5 lg:gap-10 lg:w-6/12">
-          <div className="flex justify-center order-2 lg:order-1 w-full m-auto">
+          <div className="flex justify-center order-2 lg:order-1 w-full m-auto h-[20rem] sm:h-[32rem] 2xl:h-[40rem]">
             <DinosaurTypeChart />
           </div>
           <div className="flex flex-col justify-center text-center w-4/5 m-auto order-1 lg:order-2">

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -3,13 +3,19 @@ import DinosaursNews from "../components/DinosaursNews";
 import ChartsSection from "../components/ChartsSection";
 import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
+import AboutDinosaurs from "../components/AboutDinosaurs";
 
 import { Link } from "react-router-dom";
-import AboutDinosaurs from "../components/AboutDinosaurs";
+import { useRef } from "react";
 
 const HOME_PAGE = "HOME_PAGE";
 
 function HomePage() {
+  const chartsSectionRef = useRef(null);
+
+  const scrollToChartsSection = () => {
+    chartsSectionRef.current.scrollIntoView({ behavior: "smooth" });
+  };
   return (
     <>
       <div className="h-auto pb-[70px] xl:pb-0 xl:h-screen md:min-h-[760px] bg-bg-primary relative pt-[14%] 2xl:pt-[230px]">
@@ -38,6 +44,7 @@ function HomePage() {
 
                 <button
                   type="button"
+                  onClick={scrollToChartsSection}
                   className="w-full sm:w-auto flex justify-center items-center leading-[0px] gap-3 p-3 bg-secondary-500 hover:bg-secondary-400 font-bold rounded-2xl shadow-md text-md"
                 >
                   <div className="w-[30px] h-[30px] bg-secondary-50 rounded-md shadow-md p-[5px] relative">
@@ -54,7 +61,9 @@ function HomePage() {
         </section>
       </div>
       <DinosaursNews />
+      <div ref={chartsSectionRef}>
       <ChartsSection />
+      </div>
       <AboutDinosaurs />
       <Footer />
     </>


### PR DESCRIPTION
- Fixed a bug related to Chart.js library that happened on Chrome only, on laptop-sized screen widths. When the user changed the zoom to 90%, the charts started to shrink unexpectedly. The solution for that was to set a fixed height to the charts' containers.
- Decreased the height of the charts 
- Linked the Explore Charts button to the Charts section with a slide effect