### PR TITLE
Fixed a map bug related to undefined coordinates

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -18,7 +18,8 @@ import { v4 as uuidv4 } from "uuid";
 //const position= [{lat:50.5039, lng:5.4699}, {lat:45.9432, lng:24.9668}, {lat:44.0165, lng:21.0059} ]
 
 export default function Map({ geoCoordinates }) {
-  const position = useGeoCoordinates(geoCoordinates);
+  const unfilteredPosition = useGeoCoordinates(geoCoordinates);
+  const position = unfilteredPosition.filter((coordinate) => coordinate !== null && coordinate !== undefined);
 
   //Default coordinates for centering the map (I chose France)
   const defaultPosition = { lat: 46.2276, lng: 2.2137 };


### PR DESCRIPTION
- Added a fix for a map-related bug. 
If you go to the details page of some dinosaurs like Pantydraco or Valdosaurus, you will get an error. In the json coming from the dinosaurAPI, at the foundIn countries for some dinosaurs, there are displayed both United Kingdom and Wales, or United Kingdom and England respectively. It seems that our geocoding API returns null to the coordinates coming from England and Wales. It may consider only United Kingdom as a country, as England and Wales are parts of it.
I filtered out the null coordinates (which were related to Wales and England, leaving only those for United Kingdom).
