### PR TITLE
Fixed a bug on the search results page when searching by country

### DIFF
--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -64,8 +64,9 @@ function SearchPage() {
       // Check if the dinosaur's diet matches the selected diet filter
       const dietMatches = !dietFilter || item.diet === dietFilter;
       // Check if the dinosaur is found in the selected country
-      const countryMatches =
-        !countryFilter || item.foundIn.split(",").includes(countryFilter);
+      const countryMatches = 
+        !countryFilter || item.foundIn.split(",").map(country => country.trim()).includes(countryFilter);
+
       // Apply filtering for all values that have filtering condition
       return (
         nameMatches &&


### PR DESCRIPTION
Fixed a bug on the search results page when searching by country. If a dinosaur had multiple countries at foundIn (Country 1, Country 2, Country 3), it was showing up in the search results only when searching for Country 1. When searching for Country 2 or Country 3, it didn't show up in the search results.