### PR TITLE
Fix/dinosaur detail page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^4.0.13",
         "react-router-dom": "^6.22.3",
         "react-search-autocomplete": "^8.5.2",
         "react-slick": "^0.30.2",
@@ -350,6 +351,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -4206,6 +4218,17 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.13.tgz",
+      "integrity": "sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -4329,6 +4352,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",

--- a/src/components/Router.jsx
+++ b/src/components/Router.jsx
@@ -5,12 +5,14 @@ import FavoritesPage from "../pages/FavoritesPage";
 import DinosaurDetailsPage from "../pages/DinosaurDetailsPage";
 import AboutPage from "../pages/AboutPage";
 
+import {useNavigate} from 'react-router-dom'
+
 function Router() {
+
   const router = createBrowserRouter([
     {
       path: "/",
-      element: <HomePage />,
-      errorElement: <div>ERROR 404 PAGE</div>,
+      element: <HomePage />
     },
     {
       path: "/search",
@@ -27,9 +29,16 @@ function Router() {
     {
       path: "/search/:idParameter",
       element: <DinosaurDetailsPage />,
+      errorElement: <DetailPageErrorBoundary/>
     },
   ]);
   return <RouterProvider router={router} />;
 }
+
+    function DetailPageErrorBoundary() {
+      const navigate= useNavigate()
+      navigate('/search')
+      return <SearchPage/>
+    }
 
 export default Router;

--- a/src/pages/DinosaurDetailsPage.jsx
+++ b/src/pages/DinosaurDetailsPage.jsx
@@ -4,8 +4,8 @@ import { EmptyHeart, SolidHeart } from "../assets/img/FavoritesIcons";
 import Navbar from "../components/Navbar.jsx";
 
 //React imports
-import { useParams } from "react-router-dom";
-import { useState, useContext, useEffect, useRef } from "react";
+import { useParams, } from "react-router-dom";
+import { useState, useContext, useEffect, useRef, } from "react";
 
 //Image
 import defaultDinoImage from "../assets/img/default-dino-image.png";
@@ -16,16 +16,18 @@ import updateLocalStorage from "../utils/updateLocalStorage.js";
 //App Context
 import { AppContext } from "../App.jsx";
 
+
 function DinosaurDetailsPage() {
   //Load context
   const { dinosaursData, setFavorites } = useContext(AppContext);
   //Load useParams to retrieve id
   const { idParameter } = useParams();
 
+
   const descriptionSectionRef = useRef(null);
 
   const {
-    id,
+    id ,
     name,
     imageSrc,
     description,
@@ -38,7 +40,7 @@ function DinosaurDetailsPage() {
     diet,
     typeSpecies,
     taxonomy,
-  } = dinosaursData[idParameter - 1];
+  } =  dinosaursData[idParameter-1] ;
 
   //The country is returned as a string from the Dinosaur API which is problematic when we deal with multiple countries
   //per item. We need to transform the list of countries from string to array
@@ -171,6 +173,7 @@ function DinosaurDetailsPage() {
             <Map key={id} geoCoordinates={geoCoordinates} />
           </div>
         </div>
+       
       </div>
     </>
   );


### PR DESCRIPTION
The DinosaurDetailPage is created on the fly from the Search Preview component. As such, when the page is refreshed or opened in a new tab, the route is rerendered but all details who lead to the creation of the page (the props passed from Search Preview Component) are lost. This could be solved by an architectural revamp (change the way we use Router etc) but that would take too long to implement.
Instead we added an ErrorBoundary to the DetailsPage which will just catch the error and redirect the user to the search page. It's a workaround